### PR TITLE
Fix Projects.js

### DIFF
--- a/personal-portfolio/src/components/Projects.js
+++ b/personal-portfolio/src/components/Projects.js
@@ -43,7 +43,7 @@ export const Projects = () => {
   ];
 
   return (
-    <section className="project" id="project">
+    <section className="project" id="projects">
       <Container>
         <Row>
           <Col size={12}>
@@ -79,7 +79,7 @@ export const Projects = () => {
                         }
                       </Row>
                     </Tab.Pane>
-                    <Tab.Pane eventKey="section">
+                    <Tab.Pane eventKey="second">
                       <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Cumque quam, quod neque provident velit, rem explicabo excepturi id illo molestiae blanditiis, eligendi dicta officiis asperiores delectus quasi inventore debitis quo.</p>
                     </Tab.Pane>
                     <Tab.Pane eventKey="third">


### PR DESCRIPTION
Updated two functions that had the wrong name.

### 1. Bug
When you clicked on the navbar, it didn't automatically scroll to the wrong id.

`<section className="project" id="project">` to `<section className="project" id="projects">`

### 2. Bug
When you clicked on Tab 2, it didn't show any information.

`<Tab.Pane eventKey="section">`  to `<Tab.Pane eventKey="second">`